### PR TITLE
Yan 29 Service Workers

### DIFF
--- a/packages/client/index.html
+++ b/packages/client/index.html
@@ -11,6 +11,5 @@
   <body>
     <main id="root"></main>
     <script type="module" src="/src/main.tsx"></script>
-    
   </body>
 </html>

--- a/packages/client/index.html
+++ b/packages/client/index.html
@@ -4,10 +4,13 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/icon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <script type="module" src="/src/utils/sw/registerSW.ts"></script>
+
     <title>WORMS</title>
   </head>
   <body>
     <main id="root"></main>
     <script type="module" src="/src/main.tsx"></script>
+    
   </body>
 </html>

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -57,7 +57,8 @@
     "stylelint-prettier": "3.0.0",
     "ts-jest": "28.0.8",
     "typescript": "4.9.5",
-    "vite": "3.2.6"
+    "vite": "3.2.6",
+    "vite-plugin-pwa": "^0.15.0"
   },
   "license": "MIT"
 }

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -2,7 +2,7 @@
   "name": "client",
   "version": "0.0.0",
   "scripts": {
-    "dev": "vite --host",
+    "dev": "SW_DEV=true vite --host",
     "build": "tsc && vite build",
     "preview": "vite preview",
     "lint": "eslint ./src/**/*{.ts,.tsx,.js,.jsx}",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -58,7 +58,7 @@
     "ts-jest": "28.0.8",
     "typescript": "4.9.5",
     "vite": "3.2.6",
-    "vite-plugin-pwa": "^0.15.0"
+    "vite-plugin-pwa": "0.15.0"
   },
   "license": "MIT"
 }

--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -41,6 +41,7 @@ function App() {
           <Route path={ROUTES.PROFILE} element={<Profile />} />
           <Route path={ROUTES.AUTH} element={<Auth />} />
           <Route path={ROUTES.REGISTER} element={<Register />} />
+          <Route path={ROUTES.DOCUMENTAION} element={<Documentation />} />
           <Route path={ROUTES.ERROR_404} element={<Error404 />} />
           <Route
             path="*"

--- a/packages/client/src/components/header/index.module.scss
+++ b/packages/client/src/components/header/index.module.scss
@@ -1,7 +1,6 @@
 @use '@/styles/animationMixins';
 
 .header {
-
   top: 0;
 
   display: flex;

--- a/packages/client/src/routes.ts
+++ b/packages/client/src/routes.ts
@@ -1,4 +1,3 @@
-
 export const enum ROUTES {
   MAIN = '/',
   GAME = '/game',
@@ -11,9 +10,18 @@ export const enum ROUTES {
   DOCUMENTAION = '/documentation',
 }
 
-
 export function isRoute(path: string) {
-  return ([ROUTES.MAIN, ROUTES.GAME, ROUTES.FORUM,
-     ROUTES.LEADER_BOARD, ROUTES.PROFILE, ROUTES.AUTH,
-     ROUTES.REGISTER, ROUTES.ERROR_404, ROUTES.DOCUMENTAION] as string[]).includes(path);
-} 
+  return (
+    [
+      ROUTES.MAIN,
+      ROUTES.GAME,
+      ROUTES.FORUM,
+      ROUTES.LEADER_BOARD,
+      ROUTES.PROFILE,
+      ROUTES.AUTH,
+      ROUTES.REGISTER,
+      ROUTES.ERROR_404,
+      ROUTES.DOCUMENTAION,
+    ] as string[]
+  ).includes(path)
+}

--- a/packages/client/src/routes.ts
+++ b/packages/client/src/routes.ts
@@ -11,17 +11,16 @@ export const enum ROUTES {
 }
 
 export function isRoute(path: string) {
-  return (
-    [
-      ROUTES.MAIN,
-      ROUTES.GAME,
-      ROUTES.FORUM,
-      ROUTES.LEADER_BOARD,
-      ROUTES.PROFILE,
-      ROUTES.AUTH,
-      ROUTES.REGISTER,
-      ROUTES.ERROR_404,
-      ROUTES.DOCUMENTAION,
-    ] as string[]
-  ).includes(path)
+  const routes: string[] = [
+    ROUTES.MAIN,
+    ROUTES.GAME,
+    ROUTES.FORUM,
+    ROUTES.LEADER_BOARD,
+    ROUTES.PROFILE,
+    ROUTES.AUTH,
+    ROUTES.REGISTER,
+    ROUTES.ERROR_404,
+    ROUTES.DOCUMENTAION,
+  ]
+  return routes.includes(path)
 }

--- a/packages/client/src/routes.ts
+++ b/packages/client/src/routes.ts
@@ -1,3 +1,4 @@
+
 export const enum ROUTES {
   MAIN = '/',
   GAME = '/game',
@@ -9,3 +10,10 @@ export const enum ROUTES {
   ERROR_404 = '/not-found',
   DOCUMENTAION = '/documentation',
 }
+
+
+export function isRoute(path: string) {
+  return ([ROUTES.MAIN, ROUTES.GAME, ROUTES.FORUM,
+     ROUTES.LEADER_BOARD, ROUTES.PROFILE, ROUTES.AUTH,
+     ROUTES.REGISTER, ROUTES.ERROR_404, ROUTES.DOCUMENTAION] as string[]).includes(path);
+} 

--- a/packages/client/src/sw.ts
+++ b/packages/client/src/sw.ts
@@ -1,11 +1,10 @@
 /// <reference lib="webworker" />д
 
-import logger from './utils/logger';
-import Cache from './utils/sw/Cache';
-import WormServiceWorker, { calcVersion, ManifestItem } from './utils/sw/sw';
+import logger from './utils/logger'
+import Cache from './utils/sw/Cache'
+import WormServiceWorker, { calcVersion, ManifestItem } from './utils/sw/sw'
 
-
-declare const self: ServiceWorkerGlobalScope;
+declare const self: ServiceWorkerGlobalScope
 
 // по-хорошему, надо сообщить пользователю, что он offline и попробовать анализировать флаг в utils/sw/sw
 // window.addEventListener('offline', () => showOfflineBar());
@@ -13,51 +12,50 @@ declare const self: ServiceWorkerGlobalScope;
 // запретить logout, редактирование профиля в offline
 
 // export empty type because of tsc --isolatedModules flag
-export type { };
+export type {}
 
 const SW_CACHE_NAME = 'game-worms'
-let sw: WormServiceWorker;
+let sw: WormServiceWorker
 
 function getPathItems() {
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore
-  return (self.__WB_MANIFEST || []) as ManifestItem[];
+  return (self.__WB_MANIFEST || []) as ManifestItem[]
 }
 
 async function startServiceWorker() {
-  const pathItems = getPathItems();
-  logger.log("pathItems", pathItems);
+  const pathItems = getPathItems()
+  logger.log('pathItems', pathItems)
 
   const cache = new Cache({
     cacheName: SW_CACHE_NAME,
-    version: calcVersion(pathItems)
+    version: calcVersion(pathItems),
   })
 
-  sw = new WormServiceWorker({ cache, pathItems });
+  sw = new WormServiceWorker({ cache, pathItems })
 }
 
 self.addEventListener('install', event => {
-  logger.log('install');
+  logger.log('install')
 
   self.skipWaiting()
   event.waitUntil(sw.install())
 })
 
 self.addEventListener('activate', event => {
-  logger.log('activate');
+  logger.log('activate')
   event.waitUntil(sw.activate())
 })
 
 self.addEventListener('fetch', event => {
-  logger.log(`fetch url:${event.request.url}`);
+  logger.log(`fetch url:${event.request.url}`)
 
   if (WormServiceWorker.useDefaultFetch(event)) {
-    logger.log("fetch ignore");
-    return;
+    logger.log('fetch ignore')
+    return
   }
 
   event.respondWith(sw.fetch(event))
 })
-
 
 startServiceWorker()

--- a/packages/client/src/sw.ts
+++ b/packages/client/src/sw.ts
@@ -1,0 +1,55 @@
+/// <reference lib="webworker" />д
+
+import Cache from './utils/sw/Cache';
+import WormServiceWorker, { calcVersion, createWormServiceWorker, ManifestItem } from './utils/sw/sw';
+
+declare const self: ServiceWorkerGlobalScope;
+
+
+// export empty type because of tsc --isolatedModules flag
+export type { };
+
+const SW_CACHE_NAME = 'game-worms'
+let sw: WormServiceWorker;
+
+function getPathItems() {
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
+  return (self.__WB_MANIFEST || []) as ManifestItem[];
+}
+
+async function startServiceWorker() {
+  const pathItems = getPathItems();
+  console.log("pathItems", pathItems);
+
+  const cache = new Cache({
+    cacheName: SW_CACHE_NAME,
+    version: calcVersion(pathItems)
+  })
+
+  try {
+
+    sw = await createWormServiceWorker({ cache, pathItems });
+  }
+  catch (exp) {
+    console.error(exp);
+  }
+}
+
+self.addEventListener('install', event => {
+  event.waitUntil(sw.install())
+})
+
+self.addEventListener('activate', event => {
+  console.info('activate111ggg');
+  event.waitUntil(sw.activate())
+})
+
+self.addEventListener('fetch', event => {
+  if (WormServiceWorker.defaultFetch(event)) return;
+
+  event.respondWith(sw.fetch(event))
+})
+
+
+startServiceWorker()

--- a/packages/client/src/sw.ts
+++ b/packages/client/src/sw.ts
@@ -1,10 +1,14 @@
 /// <reference lib="webworker" />д
 
 import Cache from './utils/sw/Cache';
-import WormServiceWorker, { calcVersion, createWormServiceWorker, ManifestItem } from './utils/sw/sw';
+import WormServiceWorker, { calcVersion, ManifestItem } from './utils/sw/sw';
+// import { NavigationRoute } from 'workbox-routing/NavigationRoute';
+// import { createHandlerForURL } from 'workbox-precaching/createHandlerForURL';
 
 declare const self: ServiceWorkerGlobalScope;
 
+// по-хорошему, надо сообщить пользователю, что он offline и попробовать анализировать флаг в utils/sw/sw
+// window.addEventListener('offline', () => showOfflineBar());
 
 // export empty type because of tsc --isolatedModules flag
 export type { };
@@ -20,33 +24,28 @@ function getPathItems() {
 
 async function startServiceWorker() {
   const pathItems = getPathItems();
-  console.log("pathItems", pathItems);
 
   const cache = new Cache({
     cacheName: SW_CACHE_NAME,
     version: calcVersion(pathItems)
   })
 
-  try {
-
-    sw = await createWormServiceWorker({ cache, pathItems });
-  }
-  catch (exp) {
-    console.error(exp);
-  }
+  sw = new WormServiceWorker({ cache, pathItems });
 }
 
 self.addEventListener('install', event => {
+
+  // self.skipWaiting()
   event.waitUntil(sw.install())
 })
 
 self.addEventListener('activate', event => {
-  console.info('activate111ggg');
+
   event.waitUntil(sw.activate())
 })
 
 self.addEventListener('fetch', event => {
-  if (WormServiceWorker.defaultFetch(event)) return;
+  if (WormServiceWorker.useDefaultFetch(event)) return;
 
   event.respondWith(sw.fetch(event))
 })

--- a/packages/client/src/sw.ts
+++ b/packages/client/src/sw.ts
@@ -1,14 +1,16 @@
 /// <reference lib="webworker" />д
 
+import logger from './utils/logger';
 import Cache from './utils/sw/Cache';
 import WormServiceWorker, { calcVersion, ManifestItem } from './utils/sw/sw';
-// import { NavigationRoute } from 'workbox-routing/NavigationRoute';
-// import { createHandlerForURL } from 'workbox-precaching/createHandlerForURL';
+
 
 declare const self: ServiceWorkerGlobalScope;
 
 // по-хорошему, надо сообщить пользователю, что он offline и попробовать анализировать флаг в utils/sw/sw
 // window.addEventListener('offline', () => showOfflineBar());
+// navigator.onLine
+// запретить logout, редактирование профиля в offline
 
 // export empty type because of tsc --isolatedModules flag
 export type { };
@@ -24,6 +26,7 @@ function getPathItems() {
 
 async function startServiceWorker() {
   const pathItems = getPathItems();
+  logger.log("pathItems", pathItems);
 
   const cache = new Cache({
     cacheName: SW_CACHE_NAME,
@@ -34,18 +37,24 @@ async function startServiceWorker() {
 }
 
 self.addEventListener('install', event => {
+  logger.log('install');
 
-  // self.skipWaiting()
+  self.skipWaiting()
   event.waitUntil(sw.install())
 })
 
 self.addEventListener('activate', event => {
-
+  logger.log('activate');
   event.waitUntil(sw.activate())
 })
 
 self.addEventListener('fetch', event => {
-  if (WormServiceWorker.useDefaultFetch(event)) return;
+  logger.log(`fetch url:${event.request.url}`);
+
+  if (WormServiceWorker.useDefaultFetch(event)) {
+    logger.log("fetch ignore");
+    return;
+  }
 
   event.respondWith(sw.fetch(event))
 })

--- a/packages/client/src/utils/hashCode.ts
+++ b/packages/client/src/utils/hashCode.ts
@@ -1,11 +1,10 @@
-
 export function hashCode(str: string) {
-  let hash = 0;
-  for (let i = 0, len = str.length; i < len; i+=1) {
-      const chr = str.charCodeAt(i);
-      hash = (hash << 5) - hash + chr; // eslint-disable-line no-bitwise
-      hash |= 0; // eslint-disable-line no-bitwise
-      // Convert to 32bit integer
+  let hash = 0
+  for (let i = 0, len = str.length; i < len; i += 1) {
+    const chr = str.charCodeAt(i)
+    hash = (hash << 5) - hash + chr // eslint-disable-line no-bitwise
+    hash |= 0 // eslint-disable-line no-bitwise
+    // Convert to 32bit integer
   }
-  return hash;
+  return hash
 }

--- a/packages/client/src/utils/hashCode.ts
+++ b/packages/client/src/utils/hashCode.ts
@@ -1,0 +1,11 @@
+
+export function hashCode(str: string) {
+  let hash = 0;
+  for (let i = 0, len = str.length; i < len; i+=1) {
+      const chr = str.charCodeAt(i);
+      hash = (hash << 5) - hash + chr; // eslint-disable-line no-bitwise
+      hash |= 0; // eslint-disable-line no-bitwise
+      // Convert to 32bit integer
+  }
+  return hash;
+}

--- a/packages/client/src/utils/logger.ts
+++ b/packages/client/src/utils/logger.ts
@@ -1,13 +1,9 @@
-
-
 export default class logger {
-
   static log(...args: unknown[]) {
-    console.log(...args); // eslint-disable-line no-console
+    console.log(...args) // eslint-disable-line no-console
   }
 
   static error(...args: unknown[]) {
-    console.error(...args); // eslint-disable-line no-console
+    console.error(...args) // eslint-disable-line no-console
   }
-  
 }

--- a/packages/client/src/utils/logger.ts
+++ b/packages/client/src/utils/logger.ts
@@ -1,0 +1,13 @@
+
+
+export default class logger {
+
+  static log(...args: unknown[]) {
+    console.log(...args); // eslint-disable-line no-console
+  }
+
+  static error(...args: unknown[]) {
+    console.error(...args); // eslint-disable-line no-console
+  }
+  
+}

--- a/packages/client/src/utils/sw/Cache.ts
+++ b/packages/client/src/utils/sw/Cache.ts
@@ -1,6 +1,3 @@
-
-const DEL = "::";
-
 export default class Cache {
 
   cacheNameBase: string;
@@ -12,7 +9,7 @@ export default class Cache {
   constructor({ cacheName, version }: { cacheName: string, version: string }) {
     this.cacheNameBase = cacheName
     this.version = version
-    this.cacheName = `${cacheName}${DEL}${version}`;
+    this.cacheName = `${cacheName}::${version}`;
   }
 
   private async open() {
@@ -35,7 +32,7 @@ export default class Cache {
 
   async deteleOld() {
     const cacheNames = await caches.keys()
-
+     
     return Promise.all(
       cacheNames
         .filter(name => name !== this.cacheName && name.startsWith(this.cacheNameBase))

--- a/packages/client/src/utils/sw/Cache.ts
+++ b/packages/client/src/utils/sw/Cache.ts
@@ -1,45 +1,43 @@
 export default class Cache {
+  cacheNameBase: string
 
-  cacheNameBase: string;
+  cacheName: string
 
-  cacheName: string;
+  readonly version: string
 
-  readonly version: string;
-
-  constructor({ cacheName, version }: { cacheName: string, version: string }) {
+  constructor({ cacheName, version }: { cacheName: string; version: string }) {
     this.cacheNameBase = cacheName
     this.version = version
-    this.cacheName = `${cacheName}::${version}`;
+    this.cacheName = `${cacheName}::${version}`
   }
 
   private async open() {
-    return caches.open(this.cacheName);
+    return caches.open(this.cacheName)
   }
 
   async saveAllStatic(paths: string[]) {
-    const cache = await this.open();
+    const cache = await this.open()
     return cache.addAll(paths)
   }
 
   async getSavedFetch(key: RequestInfo | URL) {
-    return caches.match(key, { cacheName: this.cacheName });
+    return caches.match(key, { cacheName: this.cacheName })
   }
 
   async saveFetch(key: RequestInfo | URL, value: Response) {
-    const cache = await this.open();
-    cache.put(key, value);
+    const cache = await this.open()
+    cache.put(key, value)
   }
 
   async deteleOld() {
     const cacheNames = await caches.keys()
-     
+
     return Promise.all(
       cacheNames
-        .filter(name => name !== this.cacheName && name.startsWith(this.cacheNameBase))
-        .map((name) => caches.delete(name))
+        .filter(
+          name => name !== this.cacheName && name.startsWith(this.cacheNameBase)
+        )
+        .map(name => caches.delete(name))
     )
-
   }
 }
-
-

--- a/packages/client/src/utils/sw/Cache.ts
+++ b/packages/client/src/utils/sw/Cache.ts
@@ -1,0 +1,48 @@
+
+const DEL = "::";
+
+export default class Cache {
+
+  cacheNameBase: string;
+
+  cacheName: string;
+
+  readonly version: string;
+
+  constructor({ cacheName, version }: { cacheName: string, version: string }) {
+    this.cacheNameBase = cacheName
+    this.version = version
+    this.cacheName = `${cacheName}${DEL}${version}`;
+  }
+
+  private async open() {
+    return caches.open(this.cacheName);
+  }
+
+  async saveAllStatic(paths: string[]) {
+    const cache = await this.open();
+    return cache.addAll(paths)
+  }
+
+  async getSavedFetch(key: RequestInfo | URL) {
+    return caches.match(key, { cacheName: this.cacheName });
+  }
+
+  async saveFetch(key: RequestInfo | URL, value: Response) {
+    const cache = await this.open();
+    cache.put(key, value);
+  }
+
+  async deteleOld() {
+    const cacheNames = await caches.keys()
+
+    return Promise.all(
+      cacheNames
+        .filter(name => name !== this.cacheName && name.startsWith(this.cacheNameBase))
+        .map((name) => caches.delete(name))
+    )
+
+  }
+}
+
+

--- a/packages/client/src/utils/sw/registerSW.ts
+++ b/packages/client/src/utils/sw/registerSW.ts
@@ -4,7 +4,7 @@ import { registerSW } from 'virtual:pwa-register';
 if ('serviceWorker' in navigator) {
 
   registerSW({
-    // immediate: true,
+    immediate: true,
     onRegisterError(error) { logger.error(error) }
   }); 
 }

--- a/packages/client/src/utils/sw/registerSW.ts
+++ b/packages/client/src/utils/sw/registerSW.ts
@@ -1,7 +1,10 @@
+import logger from '@/utils/logger';
 import { registerSW } from 'virtual:pwa-register';
 
-console.info("тут")
-
 if ('serviceWorker' in navigator) {
-  registerSW();
+
+  registerSW({
+    // immediate: true,
+    onRegisterError(error) { logger.error(error) }
+  }); 
 }

--- a/packages/client/src/utils/sw/registerSW.ts
+++ b/packages/client/src/utils/sw/registerSW.ts
@@ -1,0 +1,7 @@
+import { registerSW } from 'virtual:pwa-register';
+
+console.info("тут")
+
+if ('serviceWorker' in navigator) {
+  registerSW();
+}

--- a/packages/client/src/utils/sw/registerSW.ts
+++ b/packages/client/src/utils/sw/registerSW.ts
@@ -1,10 +1,11 @@
-import logger from '@/utils/logger';
-import { registerSW } from 'virtual:pwa-register';
+import logger from '@/utils/logger'
+import { registerSW } from 'virtual:pwa-register'
 
 if ('serviceWorker' in navigator) {
-
   registerSW({
     immediate: true,
-    onRegisterError(error) { logger.error(error) }
-  }); 
+    onRegisterError(error) {
+      logger.error(error)
+    },
+  })
 }

--- a/packages/client/src/utils/sw/sw.ts
+++ b/packages/client/src/utils/sw/sw.ts
@@ -1,101 +1,105 @@
-import { isRoute } from '../../routes';
-import { hashCode } from '../hashCode';
-import Cache from './Cache';
-import logger from '../logger';
+import { isRoute } from '../../routes'
+import { hashCode } from '../hashCode'
+import Cache from './Cache'
+import logger from '../logger'
 
-const IGNORE_METHODS = new Set(["put", "post"]);
+const IGNORE_METHODS = new Set(['put', 'post'])
 
 export type ManifestItem = {
-  url: string;
+  url: string
   revision: string | null
 }
 
 type Props = {
-  cache: Cache;
-  pathItems: ManifestItem[];
+  cache: Cache
+  pathItems: ManifestItem[]
 }
 
 export default class WormServiceWorker {
+  private cache: Cache
 
-  private cache: Cache;
-
-  private pathItems: ManifestItem[];
+  private pathItems: ManifestItem[]
 
   constructor({ cache, pathItems }: Props) {
     this.cache = cache
-    this.pathItems = pathItems;
+    this.pathItems = pathItems
   }
 
   install() {
     // добавляем новую статику в кеш
-    return this.cache.saveAllStatic(this.pathItems.map(item => item.url));
+    return this.cache.saveAllStatic(this.pathItems.map(item => item.url))
   }
 
   activate() {
     // удаляем из кеша старую статику и fetch
-    return this.cache.deteleOld();
+    return this.cache.deteleOld()
   }
 
   private static isOkResponse(response: Response) {
     // response.type = basic: Normal, same origin response, with all headers exposed except "Set-Cookie".
 
-    return (response && (response.status >= 200 && response.status < 300) && response.type === 'basic')
+    return (
+      response &&
+      response.status >= 200 &&
+      response.status < 300 &&
+      response.type === 'basic'
+    )
   }
 
   static useDefaultFetch(event: FetchEvent) {
-    return (IGNORE_METHODS.has(event.request.method.toLocaleLowerCase()));
+    return IGNORE_METHODS.has(event.request.method.toLocaleLowerCase())
   }
 
   async fetch(event: FetchEvent) {
+    let { url } = event.request
+    let isRouteUrl = false
 
-    let { url } = event.request;
-    let isRouteUrl = false;
-
-    const urlObj = new URL(url);
-    const firstPath = urlObj.pathname.split("/")[1];
+    const urlObj = new URL(url)
+    const firstPath = urlObj.pathname.split('/')[1]
     if (firstPath) {
-      isRouteUrl = (isRoute(`/${firstPath}`));
+      isRouteUrl = isRoute(`/${firstPath}`)
       if (isRouteUrl) {
-        url = `${urlObj.origin}/index.html`;
+        url = `${urlObj.origin}/index.html`
       }
     }
-     
-    // Пытаемся найти ответ на такой запрос в кеше 
-    let cachedResponse;
+
+    // Пытаемся найти ответ на такой запрос в кеше
+    let cachedResponse
     if (isRouteUrl) {
-      logger.log("route to ", url);
+      logger.log('route to ', url)
       cachedResponse = await this.cache.getSavedFetch(url)
-    }
-    else {
+    } else {
       cachedResponse = await this.cache.getSavedFetch(event.request)
     }
 
-    // Если ответ найден, выдаём его 
+    // Если ответ найден, выдаём его
     if (cachedResponse) {
-      logger.log("cachedResponse");
-      return cachedResponse;
+      logger.log('cachedResponse')
+      return cachedResponse
     }
 
-    logger.log("network");
-    // В противном случае делаем запрос на сервер 
-    const fetchRequest = event.request.clone();
-    const response = await fetch(fetchRequest);
+    logger.log('network')
+    // В противном случае делаем запрос на сервер
+    const fetchRequest = event.request.clone()
+    const response = await fetch(fetchRequest)
 
-    // Если что-то пошло не так, выдаём в основной поток результат, но не кладём его в кеш 
+    // Если что-то пошло не так, выдаём в основной поток результат, но не кладём его в кеш
     if (!WormServiceWorker.isOkResponse(response)) {
-      return response;
+      return response
     }
 
-    const responseToCache = response.clone();
-    this.cache.saveFetch(event.request, responseToCache);
+    const responseToCache = response.clone()
+    this.cache.saveFetch(event.request, responseToCache)
 
-    return response;
+    return response
   }
-
 }
 
 export function calcVersion(pathItems: ManifestItem[]) {
-  const str = pathItems.map(item => `${item.url}::${item.revision || ""}`).join("::");
-  return pathItems.length > 0 ? String(hashCode(str)) : String((new Date()).getTime());
+  const str = pathItems
+    .map(item => `${item.url}::${item.revision || ''}`)
+    .join('::')
+  return pathItems.length > 0
+    ? String(hashCode(str))
+    : String(new Date().getTime())
 }
-

--- a/packages/client/src/utils/sw/sw.ts
+++ b/packages/client/src/utils/sw/sw.ts
@@ -1,0 +1,98 @@
+import { hashCode } from '../hashCode';
+import Cache from './Cache';
+
+const IGNORE_METHODS = new Set(["put", "post"]);
+
+export type ManifestItem = {
+  url: string;
+  revision: string | null
+}
+
+type Props = {
+  // register: ServiceWorkerRegistration;
+  cache: Cache;
+  pathItems: ManifestItem[];
+}
+
+export default class WormServiceWorker {
+
+  // private register?: ServiceWorkerRegistration = undefined;
+
+  private cache: Cache;
+
+  private pathItems: ManifestItem[];
+
+  constructor({ cache, pathItems }: Props) {
+
+    // this.register = register;
+    this.cache = cache
+    this.pathItems = pathItems;
+  }
+
+
+  install() {
+    // добавляем новую статику в кеш
+    return this.cache.saveAllStatic(this.pathItems.map(item => item.url));
+  }
+
+  activate() {
+    // удаляем из кеша старую статику и fetch
+    return this.cache.deteleOld();
+  }
+
+  private static isOkResponse(response: Response) {
+    // basic: Normal, same origin response, with all headers exposed except "Set-Cookie".
+
+    return (response && (response.status >= 200 && response.status < 300) && response.type === 'basic')
+  }
+
+  static defaultFetch(event: FetchEvent) {
+    return (!IGNORE_METHODS.has(event.request.method.toLocaleLowerCase()));
+  }
+
+  async fetch(event: FetchEvent) {
+    // Пытаемся найти ответ на такой запрос в кеше 
+    // Если ответ найден, выдаём его 
+
+    const cachedResponse = await this.cache.getSavedFetch(event.request)
+
+    if (cachedResponse) {
+      return cachedResponse;
+    }
+
+    // В противном случае делаем запрос на сервер 
+    const fetchRequest = event.request.clone();
+    const response = await fetch(fetchRequest);
+
+
+    // Если что-то пошло не так, выдаём в основной поток результат, но не кладём его в кеш 
+    if (!WormServiceWorker.isOkResponse(response)) {
+      return response;
+    }
+
+    const responseToCache = response.clone();
+    this.cache.saveFetch(event.request, responseToCache);
+
+    return response;
+  }
+
+}
+
+export function calcVersion(pathItems: ManifestItem[]) {
+  const str = pathItems.map(item => `${item.url}::${item.revision || ""}`).join("::");
+  return String(hashCode(str));
+}
+
+export function availableServiceWorker() {
+  return ('serviceWorker' in navigator);
+}
+
+export async function createWormServiceWorker({ cache, pathItems }: { cache: Cache; pathItems: ManifestItem[] }) {
+  // if (!availableServiceWorker) throw new Error("Not supported ServiceWorker");
+
+ // const register = await navigator.serviceWorker.register(path);
+  const sw = new WormServiceWorker({ cache, pathItems });
+  return sw
+}
+
+

--- a/packages/client/src/utils/sw/sw.ts
+++ b/packages/client/src/utils/sw/sw.ts
@@ -96,6 +96,6 @@ export default class WormServiceWorker {
 
 export function calcVersion(pathItems: ManifestItem[]) {
   const str = pathItems.map(item => `${item.url}::${item.revision || ""}`).join("::");
-  return String(hashCode(str));
+  return pathItems.length > 0 ? String(hashCode(str)) : String((new Date()).getTime());
 }
 

--- a/packages/client/src/utils/sw/sw.ts
+++ b/packages/client/src/utils/sw/sw.ts
@@ -9,26 +9,20 @@ export type ManifestItem = {
 }
 
 type Props = {
-  // register: ServiceWorkerRegistration;
   cache: Cache;
   pathItems: ManifestItem[];
 }
 
 export default class WormServiceWorker {
 
-  // private register?: ServiceWorkerRegistration = undefined;
-
   private cache: Cache;
 
   private pathItems: ManifestItem[];
 
   constructor({ cache, pathItems }: Props) {
-
-    // this.register = register;
     this.cache = cache
     this.pathItems = pathItems;
   }
-
 
   install() {
     // добавляем новую статику в кеш
@@ -41,21 +35,20 @@ export default class WormServiceWorker {
   }
 
   private static isOkResponse(response: Response) {
-    // basic: Normal, same origin response, with all headers exposed except "Set-Cookie".
+    // response.type = basic: Normal, same origin response, with all headers exposed except "Set-Cookie".
 
     return (response && (response.status >= 200 && response.status < 300) && response.type === 'basic')
   }
 
-  static defaultFetch(event: FetchEvent) {
-    return (!IGNORE_METHODS.has(event.request.method.toLocaleLowerCase()));
+  static useDefaultFetch(event: FetchEvent) {
+    return (IGNORE_METHODS.has(event.request.method.toLocaleLowerCase()));
   }
 
   async fetch(event: FetchEvent) {
     // Пытаемся найти ответ на такой запрос в кеше 
-    // Если ответ найден, выдаём его 
-
     const cachedResponse = await this.cache.getSavedFetch(event.request)
 
+    // Если ответ найден, выдаём его 
     if (cachedResponse) {
       return cachedResponse;
     }
@@ -63,7 +56,6 @@ export default class WormServiceWorker {
     // В противном случае делаем запрос на сервер 
     const fetchRequest = event.request.clone();
     const response = await fetch(fetchRequest);
-
 
     // Если что-то пошло не так, выдаём в основной поток результат, но не кладём его в кеш 
     if (!WormServiceWorker.isOkResponse(response)) {
@@ -82,17 +74,4 @@ export function calcVersion(pathItems: ManifestItem[]) {
   const str = pathItems.map(item => `${item.url}::${item.revision || ""}`).join("::");
   return String(hashCode(str));
 }
-
-export function availableServiceWorker() {
-  return ('serviceWorker' in navigator);
-}
-
-export async function createWormServiceWorker({ cache, pathItems }: { cache: Cache; pathItems: ManifestItem[] }) {
-  // if (!availableServiceWorker) throw new Error("Not supported ServiceWorker");
-
- // const register = await navigator.serviceWorker.register(path);
-  const sw = new WormServiceWorker({ cache, pathItems });
-  return sw
-}
-
 

--- a/packages/client/tsconfig.json
+++ b/packages/client/tsconfig.json
@@ -30,15 +30,13 @@
       "@/canvas/*": ["canvas/*"],
       "@/store/*": ["store/*"]
     },
-    "types": [
-      "vite-plugin-pwa/client"
-    ]
+    "types": ["vite-plugin-pwa/client"]
   },
   "include": [
     ".eslintrc.js",
     "./src/**/*",
     "typing/app.d.ts",
     "typing/react.d.ts"
- ],
+  ],
   "references": [{ "path": "./tsconfig.node.json" }]
 }

--- a/packages/client/tsconfig.json
+++ b/packages/client/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "ESNext",
     "useDefineForClassFields": true,
-    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "lib": ["DOM", "DOM.Iterable", "ESNext" /*, "webworker" */],
     "allowJs": false,
     "skipLibCheck": true,
     "esModuleInterop": false,
@@ -12,7 +12,7 @@
     "module": "ESNext",
     "moduleResolution": "Node",
     "resolveJsonModule": true,
-    "isolatedModules": true,
+    "isolatedModules": false,
     "noEmit": true,
     "jsx": "react-jsx",
     "baseUrl": "./src",
@@ -29,13 +29,16 @@
       "@/hooks/*": ["hooks/*"],
       "@/canvas/*": ["canvas/*"],
       "@/store/*": ["store/*"]
-    }
+    },
+    "types": [
+      "vite-plugin-pwa/client"
+    ]
   },
   "include": [
     ".eslintrc.js",
     "./src/**/*",
     "typing/app.d.ts",
     "typing/react.d.ts"
-  ],
+ ],
   "references": [{ "path": "./tsconfig.node.json" }]
 }

--- a/packages/client/tsconfig.json
+++ b/packages/client/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "ESNext",
     "useDefineForClassFields": true,
-    "lib": ["DOM", "DOM.Iterable", "ESNext" /*, "webworker" */],
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
     "allowJs": false,
     "skipLibCheck": true,
     "esModuleInterop": false,
@@ -12,7 +12,7 @@
     "module": "ESNext",
     "moduleResolution": "Node",
     "resolveJsonModule": true,
-    "isolatedModules": false,
+    "isolatedModules": true,
     "noEmit": true,
     "jsx": "react-jsx",
     "baseUrl": "./src",

--- a/packages/client/vite.config.ts
+++ b/packages/client/vite.config.ts
@@ -1,6 +1,7 @@
 import { defineConfig, loadEnv } from 'vite'
 import react from '@vitejs/plugin-react'
 import svgr from 'vite-plugin-svgr'
+import { VitePWA } from 'vite-plugin-pwa'
 
 import dotenv from 'dotenv'
 
@@ -19,7 +20,37 @@ export default ({ mode }) => {
     define: {
       __SERVER_PORT__: process.env.SERVER_PORT,
     },
-    plugins: [svgr(), react()],
+    plugins: [svgr(), react(),
+    VitePWA({
+      srcDir: "src",
+      filename: "sw.ts",
+      strategies: "injectManifest",
+      injectManifest: {
+        globPatterns: ["**/*.{js,css,html,svg,png,jpg,ico,woff,woff2}"]
+        //rollupFormat: 'iife'
+      },
+      injectRegister: false,
+      manifest: false,
+      //devOptions: {
+      //  enabled: true, 
+      //  type: 'module',
+      //},
+      workbox: {
+        sourcemap: true
+      }
+    })],
+
+    build: {
+      manifest: true,
+      rollupOptions: {
+        external: [
+          "utils/sw/Cache",
+          "utils/sw/sw",
+          "utils/hashCode",
+        ],
+      },
+    },
+
     resolve: {
       alias: {
         '@/api': path.resolve(__dirname, './src/api'),

--- a/packages/client/vite.config.ts
+++ b/packages/client/vite.config.ts
@@ -20,37 +20,40 @@ export default ({ mode }) => {
     define: {
       __SERVER_PORT__: process.env.SERVER_PORT,
     },
-    plugins: [svgr(), react(),
-    VitePWA({
-      srcDir: "src",
-      filename: "sw.ts",
-      strategies: "injectManifest",
-      injectManifest: {
-        globPatterns: ["**/*.{js,css,html,svg,png,jpg,ico,woff,woff2}"],
-        maximumFileSizeToCacheInBytes: 5 * 1024 * 1024 // по умолчанию 2 МБ, можно увеличить этой настройкой
-      },
-      injectRegister: false,
-      manifest: false,
-      devOptions: {
-        enabled: process.env.SW_DEV === 'true',
-        type: 'module',
-      },
-      workbox: {
-        sourcemap: true
-      },
-      registerType: 'autoUpdate',
-      // selfDestroying: true,
-    })],
+    plugins: [
+      svgr(),
+      react(),
+      VitePWA({
+        srcDir: 'src',
+        filename: 'sw.ts',
+        strategies: 'injectManifest',
+        injectManifest: {
+          globPatterns: ['**/*.{js,css,html,svg,png,jpg,ico,woff,woff2}'],
+          maximumFileSizeToCacheInBytes: 5 * 1024 * 1024, // по умолчанию 2 МБ, можно увеличить этой настройкой
+        },
+        injectRegister: false,
+        manifest: false,
+        devOptions: {
+          enabled: process.env.SW_DEV === 'true',
+          type: 'module',
+        },
+        workbox: {
+          sourcemap: true,
+        },
+        registerType: 'autoUpdate',
+        // selfDestroying: true,
+      }),
+    ],
 
     build: {
       manifest: true,
       rollupOptions: {
         external: [
-          "utils/sw/Cache",
-          "utils/sw/sw",
-          "utils/hashCode",
-          "utils/logger",
-          "routes"
+          'utils/sw/Cache',
+          'utils/sw/sw',
+          'utils/hashCode',
+          'utils/logger',
+          'routes',
         ],
       },
     },

--- a/packages/client/vite.config.ts
+++ b/packages/client/vite.config.ts
@@ -41,7 +41,6 @@ export default ({ mode }) => {
           sourcemap: true,
         },
         registerType: 'autoUpdate',
-        // selfDestroying: true,
       }),
     ],
 

--- a/packages/client/vite.config.ts
+++ b/packages/client/vite.config.ts
@@ -27,17 +27,19 @@ export default ({ mode }) => {
       strategies: "injectManifest",
       injectManifest: {
         globPatterns: ["**/*.{js,css,html,svg,png,jpg,ico,woff,woff2}"]
-        //rollupFormat: 'iife'
+        //maximumFileSizeToCacheInBytes: по умолчанию 2 МБ, можно увеличить этой настройкой
       },
       injectRegister: false,
       manifest: false,
-      //devOptions: {
-      //  enabled: true, 
-      //  type: 'module',
-      //},
+      devOptions: {
+        enabled: process.env.SW_DEV === 'true',
+        type: 'module',
+      },
       workbox: {
         sourcemap: true
-      }
+      },
+      registerType: 'autoUpdate',
+      // selfDestroying: true,
     })],
 
     build: {
@@ -47,6 +49,7 @@ export default ({ mode }) => {
           "utils/sw/Cache",
           "utils/sw/sw",
           "utils/hashCode",
+          "utils/logger"
         ],
       },
     },

--- a/packages/client/vite.config.ts
+++ b/packages/client/vite.config.ts
@@ -26,8 +26,8 @@ export default ({ mode }) => {
       filename: "sw.ts",
       strategies: "injectManifest",
       injectManifest: {
-        globPatterns: ["**/*.{js,css,html,svg,png,jpg,ico,woff,woff2}"]
-        //maximumFileSizeToCacheInBytes: по умолчанию 2 МБ, можно увеличить этой настройкой
+        globPatterns: ["**/*.{js,css,html,svg,png,jpg,ico,woff,woff2}"],
+        maximumFileSizeToCacheInBytes: 5 * 1024 * 1024 // по умолчанию 2 МБ, можно увеличить этой настройкой
       },
       injectRegister: false,
       manifest: false,
@@ -49,7 +49,8 @@ export default ({ mode }) => {
           "utils/sw/Cache",
           "utils/sw/sw",
           "utils/hashCode",
-          "utils/logger"
+          "utils/logger",
+          "routes"
         ],
       },
     },

--- a/packages/server/global.d.ts
+++ b/packages/server/global.d.ts
@@ -1,6 +1,5 @@
-
 declare module 'express-history-api-fallback' {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const _a: any;
-  export = _a;
+  const _a: any
+  export = _a
 }

--- a/packages/server/global.d.ts
+++ b/packages/server/global.d.ts
@@ -1,0 +1,6 @@
+
+declare module 'express-history-api-fallback' {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const _a: any;
+  export = _a;
+}

--- a/packages/server/index.ts
+++ b/packages/server/index.ts
@@ -4,17 +4,27 @@ dotenv.config()
 
 import express from 'express'
 import { createClientAndConnect } from './db'
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+import fallback from "express-history-api-fallback";
+import path from 'path';
+
+const root = path.resolve(__dirname, '../client/dist');
 
 const app = express()
 app.use(cors())
-const port = Number(process.env.SERVER_PORT) || 3001
+const port = Number(process.env.SERVER_PORT) || 3003
 
 createClientAndConnect()
 
-app.get('/', (_, res) => {
-  res.json('👋 Howdy from the server :)')
-})
+//app.get('/', (_, res) => {
+//  res.json('👋 Howdy from the server :)')
+//})
+
+app.use(express.static(root));
+app.use(fallback("index.html", { root }));
 
 app.listen(port, () => {
   console.log(`  ➜ 🎸 Server is listening on port: ${port}`)
 })
+
+// lsof -i :3001 -t

--- a/packages/server/index.ts
+++ b/packages/server/index.ts
@@ -2,7 +2,7 @@ import dotenv from 'dotenv'
 import cors from 'cors'
 import express from 'express'
 
-//import fallback from "express-history-api-fallback";
+import fallback from "express-history-api-fallback";
 import path from 'path';
 
 //import { createClientAndConnect } from './db'
@@ -20,14 +20,9 @@ const port = Number(process.env.SERVER_PORT) || 4002
 //  res.json('👋 Howdy from the server :)')
 //})
 
- app.use(function (_req, _res, next) {
-  console.log(_req.url);
-  //res.setHeader('Cache-Control', 'public, max-age=120'); //, must-revalidate
-  next();
-}); 
 
 app.use(express.static(root));
-//app.use(fallback("index.html", { root }));
+app.use(fallback("index.html", { root }));
 
 
 app.listen(port, () => {

--- a/packages/server/index.ts
+++ b/packages/server/index.ts
@@ -2,13 +2,13 @@ import dotenv from 'dotenv'
 import cors from 'cors'
 import express from 'express'
 
-import fallback from "express-history-api-fallback";
-import path from 'path';
+import fallback from 'express-history-api-fallback'
+import path from 'path'
 
 //import { createClientAndConnect } from './db'
 
 dotenv.config()
-const root = path.resolve(__dirname, '../client/dist');
+const root = path.resolve(__dirname, '../client/dist')
 
 const app = express()
 app.use(cors())
@@ -20,10 +20,8 @@ const port = Number(process.env.SERVER_PORT) || 3001
 //  res.json('👋 Howdy from the server :)')
 //})
 
-
-app.use(express.static(root));
-app.use(fallback("index.html", { root }));
-
+app.use(express.static(root))
+app.use(fallback('index.html', { root }))
 
 app.listen(port, () => {
   console.log(`  ➜ 🎸 Server is listening on port: ${port}`)

--- a/packages/server/index.ts
+++ b/packages/server/index.ts
@@ -12,7 +12,7 @@ const root = path.resolve(__dirname, '../client/dist');
 
 const app = express()
 app.use(cors())
-const port = Number(process.env.SERVER_PORT) || 4002
+const port = Number(process.env.SERVER_PORT) || 3001
 
 //createClientAndConnect()
 

--- a/packages/server/index.ts
+++ b/packages/server/index.ts
@@ -1,27 +1,34 @@
 import dotenv from 'dotenv'
 import cors from 'cors'
-dotenv.config()
-
 import express from 'express'
-import { createClientAndConnect } from './db'
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-import fallback from "express-history-api-fallback";
+
+//import fallback from "express-history-api-fallback";
 import path from 'path';
 
+//import { createClientAndConnect } from './db'
+
+dotenv.config()
 const root = path.resolve(__dirname, '../client/dist');
 
 const app = express()
 app.use(cors())
-const port = Number(process.env.SERVER_PORT) || 3003
+const port = Number(process.env.SERVER_PORT) || 4002
 
-createClientAndConnect()
+//createClientAndConnect()
 
 //app.get('/', (_, res) => {
 //  res.json('👋 Howdy from the server :)')
 //})
 
+ app.use(function (_req, _res, next) {
+  console.log(_req.url);
+  //res.setHeader('Cache-Control', 'public, max-age=120'); //, must-revalidate
+  next();
+}); 
+
 app.use(express.static(root));
-app.use(fallback("index.html", { root }));
+//app.use(fallback("index.html", { root }));
+
 
 app.listen(port, () => {
   console.log(`  ➜ 🎸 Server is listening on port: ${port}`)

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -12,11 +12,13 @@
     "test": "jest ."
   },
   "dependencies": {
+    "@types/connect-history-api-fallback": "^1.5.0",
     "cors": "2.8.5",
     "cross-env": "7.0.3",
     "dotenv": "16.0.3",
     "eslint-config-prettier": "8.8.0",
     "express": "4.18.2",
+    "express-history-api-fallback": "^2.2.1",
     "pg": "8.10.0",
     "prettier": "2.8.8"
   },

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -17,7 +17,7 @@
     "dotenv": "16.0.3",
     "eslint-config-prettier": "8.8.0",
     "express": "4.18.2",
-    "express-history-api-fallback": "^2.2.1",
+    "express-history-api-fallback": "2.2.1",
     "pg": "8.10.0",
     "prettier": "2.8.8"
   },

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -5,14 +5,13 @@
   "scripts": {
     "build": "rm -rf ./dist && tsc --p ./tsconfig.prod.json",
     "preview": "node ./dist/index.js",
-    "dev": "cross-env NODE_ENV=development nodemon index.ts",
+    "dev": "cross-env NODE_ENV=development nodemon --watch '*.ts' --exec 'ts-node' --files index.ts",
     "lint": "eslint .",
     "style-lint": "",
     "format": "prettier --write .",
     "test": "jest ."
   },
   "dependencies": {
-    "@types/connect-history-api-fallback": "^1.5.0",
     "cors": "2.8.5",
     "cross-env": "7.0.3",
     "dotenv": "16.0.3",

--- a/packages/server/server.d.ts
+++ b/packages/server/server.d.ts
@@ -1,0 +1,1 @@
+declare module 'express-history-api-fallback'

--- a/packages/server/server.d.ts
+++ b/packages/server/server.d.ts
@@ -1,1 +1,0 @@
-declare module 'express-history-api-fallback'


### PR DESCRIPTION
### Какую задачу решаем
SW = service workers
Добавить Service Workers. Приложение должно попадать в кеш при первой загрузке и после этого загружаться без интернета (не только элементы входа и пользовательские настройки, но и сама игра).

Доработан server, добавлен [server history-api-fallback]. Если что-то не так, просьба отмечать как "предложение", а не "ошибка". Добавлено только, чтобы можно было тестировать SW

Проблемы - 
код для SW не удалось подружить с алиасами (их там нет специально, еще для поддержки импорта в SW добавляла rollupOptions.external)
работает только в безопасном контексте - https и localhost
https - сейчас нет (но vercel публикует на https)
если проверять локально - то запускать server и проверять на нем

Service Workers имеют свою стратегию кеширования, никак не реагируют на Cache-Control приложения
Если поставить точку остановки в Service Workers, то запросы уходят в бесконечное ожидание, поэтому добавлено логирование
Если отключить сеть на вкладке, все равно на сервер прилетает запрос sw.js (надо отключать сервер для проверки)
Проверять надо на порту сервера, а не на сервере отладки от vite  (там тоже включена работа с SW, но скорее всего надо вести два конфига для отладки и для прод. И для отладки совсем выключать SW)
Если поставить галочку "Отключить кеш" в отладчике - то так же получаем проблему, что запросы уходят в бесконечное ожидание
Если я верно поняла, при работе с SW вкладку браузер переводит в автономный режим сам

### Скриншоты/видяшка (если есть)
![image](https://github.com/ThunderbirdSecret/Game_Project/assets/12953732/a311d397-62f0-42b5-8f59-fbf82a4e6d91)
![image](https://github.com/ThunderbirdSecret/Game_Project/assets/12953732/97d80fe4-76ef-463c-90ac-7785adf0b26f)
![image](https://github.com/ThunderbirdSecret/Game_Project/assets/12953732/71c3071d-9ef4-4ae7-a9dd-f8455a2ec3d3)
порт на скриншоте отладочный, будет тот который указан в server (const port = Number(process.env.SERVER_PORT) || 5001)
### TBD (если есть)